### PR TITLE
Fix ignored excludeFiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
         "body": "APP-[0-9]+",
         "flags": "g"
       },
-      "excludeFiles": [ "-test.js", ".less"],
+      "excludeFiles": [ "\\-test.(js|ts)$", "\\.less$"],
       "addedFilesQualityGate": {
         "statements": 100,
         "branches": 100,
@@ -88,7 +88,7 @@
   
    - [flags](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Advanced_searching_with_flags): search flags, for example `"flags": "g"` will look for matches globally in branch name and in commit messages.
   
-* **`excludeFiles`** - array of file extensions that should be ignored by check
+* **`excludeFiles`** - array of filename regexp bodies that should be ignored by check
 * **`addedFilesQualityGate`** - config object where you specify quality gate for newly added files, defaults to:
 ```json
 {

--- a/src/coverage-guard.js
+++ b/src/coverage-guard.js
@@ -248,7 +248,7 @@ class CoverageGuard {
     }
 
     checkCoverageOnFiles(files, qualityGate) {
-        const appFiles = getAppFiles(files, this.filesToSkip);
+        const appFiles = getAppFiles(files, this.config.excludeFiles, this.filesToSkip);
 
         if (files.length && !appFiles.length) {
             console.log(YELLOW_LOG_ERR, 'No changed files found in your project root folder, check your appRootRelativeToGitRepo config');

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,7 @@ function getAppFiles(files, excludeFiles, filesToSkip) {
     return files.filter(
         filePath =>
             filePath.startsWith(config.appRootRelativeToGitRepo) &&
-            !excludeFiles.some(excludeFile => new RegExp(excludeFile).test(path.basename(filePath))),
+            !excludeFiles.some(excludeFile => new RegExp(excludeFile).test(path.basename(filePath))) &&
             !filesToSkip.includes(filePath)
     );
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,17 +1,17 @@
 const appRoot = require('app-root-path');
 const config = require(appRoot + '/coverage.guard.config.json');
+const path = require('path');
 
 function getCommitHashes(commits) {
     return commits.map(commit => commit.hash).reverse();
 }
 
-function getAppFiles(files, filesToSkip) {
+function getAppFiles(files, excludeFiles, filesToSkip) {
     // we can use startsWith and endsWith since this script is expected only in node
     return files.filter(
         filePath =>
             filePath.startsWith(config.appRootRelativeToGitRepo) &&
-            !filePath.endsWith('-test.js') && // exclude test files
-            !filePath.endsWith('.less') && // exclude less files
+            !excludeFiles.some(excludeFile => new RegExp(excludeFile).test(path.basename(filePath))),
             !filesToSkip.includes(filePath)
     );
 


### PR DESCRIPTION
From the code, it appears that the values in the `excludeFiles` config key were hardcoded, and the config was only initialized and never used.